### PR TITLE
Remove check for if a file is open before activating project.nvim

### DIFF
--- a/lua/project_nvim/project.lua
+++ b/lua/project_nvim/project.lua
@@ -231,10 +231,6 @@ function M.on_buf_enter()
     return
   end
 
-  if not M.is_file() then
-    return
-  end
-
   local root, method = M.get_project_root()
   M.set_pwd(root, method)
 end


### PR DESCRIPTION
Fix suggestion 2 for #5 
This should would regardless of how vim is opened etc.