### PR TITLE
Fix find_pattern_root for buffers with arbitrary paths

### DIFF
--- a/lua/project_nvim/project.lua
+++ b/lua/project_nvim/project.lua
@@ -127,7 +127,7 @@ function M.find_pattern_root()
     end
 
     local parent = get_parent(search_dir)
-    if parent == search_dir then
+    if parent == search_dir or parent == nil then
       return nil
     end
 


### PR DESCRIPTION
Fixed problem with plugins such as Diffview giving the following error:
```
E5108: Error executing lua ...m/site/pack/packer/start/tmux.nvim/lua/tmux/navigate.lua:56: Vim(lua):E5108: Error executing lua ...k/packer/start/projec
t.nvim/lua/project_nvim/project.lua:49: bad argument #1 to 'fs_scandir' (string expected, got nil)
```

Due to the path "%" of a buffer being arbitrarily set (e.g. diffview/some_file.txt).