### PR TITLE
fix: require('telescope.actions').get_selected_entry() is deprecated

### DIFF
--- a/lua/telescope/_extensions/projects.lua
+++ b/lua/telescope/_extensions/projects.lua
@@ -11,6 +11,7 @@ local finders = require("telescope.finders")
 local pickers = require("telescope.pickers")
 local telescope_config = require("telescope.config").values
 local actions = require("telescope.actions")
+local state = require("telescope.actions.state")
 local builtin = require("telescope.builtin")
 local entry_display = require("telescope.pickers.entry_display")
 
@@ -23,7 +24,7 @@ local config = require("project_nvim.config")
 ----------
 
 local function change_working_directory(prompt_bufnr, prompt)
-  local selected_entry = actions.get_selected_entry(prompt_bufnr)
+  local selected_entry = state.get_selected_entry(prompt_bufnr)
   if selected_entry == nil then
     actions.close(prompt_bufnr)
     return


### PR DESCRIPTION
Telescope keeps giving the following warning

```
[telescope] [INFO  06:05:53] ...packer/opt/telescope.nvim/lua/telescope/actions/init.lua:60: `actions.get_selected_entry()` is deprecated.Use require('telescope.act
ions.state').get_selected_entry() instead
1 change; before #147  1 second ago
```
This PR basically just changes the deprecated function to the new one :)