### PR TITLE
fix(cwd): fallback to current dir if buffer not in project

### DIFF
--- a/lua/project_nvim/project.lua
+++ b/lua/project_nvim/project.lua
@@ -237,6 +237,13 @@ function M.on_buf_enter()
   end
 
   local root, method = M.get_project_root()
+
+  -- Fallback to current dir if buffer is not in any project
+  if root == nil then
+    root = current_dir
+    method = 'CWD'
+  end
+
   M.set_pwd(root, method)
 end
 


### PR DESCRIPTION
Bug case:

1. Launch nvim with a file in non-project directory
2. Switch to another project-related file (via history or project switching)  -> `get_cwd()` changed to the project root
3. Switch back to the non-project buffer -> `get_cwd()` still keeps the previous project root, which is expected to be containing directory of current buffer