### PR TITLE
feat: add patterns fallback

### DIFF
--- a/README.md
+++ b/README.md
@@ -120,6 +120,10 @@ use {
   -- Path where project.nvim will store the project history for use in
   -- telescope
   datapath = vim.fn.stdpath("data"),
+
+  -- If all patterns fail to match, project.nvim will change the directory to
+  -- current buffer's location
+  patterns_fallback = false,
 }
 ```
 

--- a/lua/project_nvim/config.lua
+++ b/lua/project_nvim/config.lua
@@ -34,6 +34,10 @@ M.defaults = {
   -- Path where project.nvim will store the project history for use in
   -- telescope
   datapath = vim.fn.stdpath("data"),
+
+  -- If all patterns fail to match, project.nvim will change the directory to
+  -- current buffer's location
+  patterns_fallback = false,
 }
 
 ---@type ProjectOptions

--- a/lua/project_nvim/project.lua
+++ b/lua/project_nvim/project.lua
@@ -171,6 +171,7 @@ end
 
 function M.set_pwd(dir, method)
   if dir ~= nil then
+    dir = uv.fs_realpath(dir)
     M.last_project = dir
     table.insert(history.session_projects, dir)
 
@@ -185,7 +186,7 @@ function M.set_pwd(dir, method)
   end
 
   if config.options.patterns_fallback == true then
-    dir = vim.fn.expand("%:p:h") 
+    dir = vim.fn.expand("%:p:h")
     if vim.fn.getcwd() ~= dir then
       vim.api.nvim_set_current_dir(vim.fn.expand("%:p:h"))
       if config.options.silent_chdir == false then

--- a/lua/project_nvim/project.lua
+++ b/lua/project_nvim/project.lua
@@ -184,6 +184,16 @@ function M.set_pwd(dir, method)
     return true
   end
 
+  if config.options.patterns_fallback == true then
+    dir = vim.fn.expand("%:p:h") 
+    if vim.fn.getcwd() ~= dir then
+      vim.api.nvim_set_current_dir(vim.fn.expand("%:p:h"))
+      if config.options.silent_chdir == false then
+        vim.notify("Set CWD to " .. dir .. " using " .. "fallback")
+      end
+    end
+  end
+
   return false
 end
 


### PR DESCRIPTION
This pr add a setup option `patterns_fallback` which is false by default. When it is set to ture and all patterns fail to match, project.nvim will change the directory to current buffer's location. [vim-rooter](https://github.com/airblade/vim-rooter) also support this kind of setting

see also #56 