### PR TITLE
Add `mode = 'insert'` to opts table

### DIFF
--- a/lua/telescope/_extensions/projects.lua
+++ b/lua/telescope/_extensions/projects.lua
@@ -80,6 +80,7 @@ local function find_project_files(prompt_bufnr)
   local opt = {
     cwd = project_path,
     hidden = config.options.show_hidden,
+    mode = "insert",
   }
   if cd_successful then
     builtin.find_files(opt)
@@ -102,6 +103,7 @@ local function search_in_project_files(prompt_bufnr)
   local opt = {
     cwd = project_path,
     hidden = config.options.show_hidden,
+    mode = "insert",
   }
   if cd_successful then
     builtin.live_grep(opt)


### PR DESCRIPTION
It would be useful if, once a project is selected, telescope find_files opens in insert mode instead of "normal mode". This would allow the user to start tying their search string immediately instead of first typing `i`. 

Opening telescope `find_files` in "normal mode" is inconsistent with normal telescope behaviour.

This PR adds an argument `mode = "insert"` to the `opt` table for the functions `find_project_files` and `search_in_project_files` (I'm not sure what the difference is between these functions). 

This makes telescope find_files open in insert mode once a project has been selected.

This would close #54  