### PR TITLE
Update README to adapt the latest nvim-tree version

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,11 +22,10 @@ superior project management.
   - Please add the following to your config instead:
     ```vim
     " Vim Script
-    let g:nvim_tree_respect_buf_cwd = 1
-    
     lua << EOF
     require("nvim-tree").setup({
       update_cwd = true,
+      respect_buf_cwd = true,
       update_focused_file = {
         enable = true,
         update_cwd = true
@@ -36,9 +35,8 @@ superior project management.
     ```
     ```lua
     -- lua
-    vim.g.nvim_tree_respect_buf_cwd = 1
-    
     require("nvim-tree").setup({
+      respect_buf_cwd = true,
       update_cwd = true,
       update_focused_file = {
         enable = true,


### PR DESCRIPTION
VimScript style configuration is fully deprecated in the latest version of nvim-tree,
move config to Lua setup function.