### PR TITLE
Feat: Allow creation of custom callbacks, executed before and after project selection.

### DIFF
--- a/README.md
+++ b/README.md
@@ -120,8 +120,13 @@ use {
   datapath = vim.fn.stdpath("data"),
 
   -- Allows the user to declare a custom callback to execute on project 
+  -- before a new project is selected and the working directory is changed.
+  -- Setting this to false means that nothing will be executed.
+  before_project_selection_callback = false,
+
+  -- Allows the user to declare a custom callback to execute on project 
   -- selection. Setting this to false means that nothing will be executed.
-  custom_callback = false,
+  after_project_selection_callback = false,
 }
 ```
 

--- a/README.md
+++ b/README.md
@@ -118,6 +118,10 @@ use {
   -- Path where project.nvim will store the project history for use in
   -- telescope
   datapath = vim.fn.stdpath("data"),
+
+  -- Allows the user to declare a custom callback to execute on project 
+  -- selection. Setting this to false means that nothing will be executed.
+  custom_callback = false,
 }
 ```
 

--- a/lua/project_nvim/config.lua
+++ b/lua/project_nvim/config.lua
@@ -34,6 +34,9 @@ M.defaults = {
   -- Path where project.nvim will store the project history for use in
   -- telescope
   datapath = vim.fn.stdpath("data"),
+
+  -- Allows the user to declare a custom callback to execute on project selection
+  custom_callback = false,
 }
 
 ---@type ProjectOptions

--- a/lua/project_nvim/config.lua
+++ b/lua/project_nvim/config.lua
@@ -35,8 +35,12 @@ M.defaults = {
   -- telescope
   datapath = vim.fn.stdpath("data"),
 
-  -- Allows the user to declare a custom callback to execute on project selection
-  custom_callback = false,
+  -- Allows the user to declare a custom callback to execute before project selection
+  -- occurs, such as when moving from one project to another
+  before_project_selection_callback = false,
+
+  -- Allows the user to declare a custom callback to execute after project selection
+  after_project_selection_callback = false,
 }
 
 ---@type ProjectOptions

--- a/lua/telescope/_extensions/projects.lua
+++ b/lua/telescope/_extensions/projects.lua
@@ -166,7 +166,11 @@ local function projects(opts)
 
       local on_project_selected = function()
         find_project_files(prompt_bufnr)
+        if(config.options.custom_callback) then
+          config.options.custom_callback()
+        end
       end
+
       actions.select_default:replace(on_project_selected)
       return true
     end,

--- a/lua/telescope/_extensions/projects.lua
+++ b/lua/telescope/_extensions/projects.lua
@@ -165,9 +165,14 @@ local function projects(opts)
       map("i", "<c-w>", change_working_directory)
 
       local on_project_selected = function()
+        if(config.options.before_project_selection_callback) then
+          config.options.before_project_selection_callback()
+        end
+
         find_project_files(prompt_bufnr)
-        if(config.options.custom_callback) then
-          config.options.custom_callback()
+
+        if(config.options.after_project_selection_callback) then
+          config.options.after_project_selection_callback()
         end
       end
 


### PR DESCRIPTION
Hi all,

This is a quick change that allows users to create a custom callback that executes after a project is selected. I believe this helps push toward a solution for #73 #76  and maybe #49.

For example, I use the following with `vim-obsession`:

```lua
local function loadSession()
 if(vim.fn.filereadable('Session.vim') ~= 0) then
   -- start a new scratch file just to stop nvim from throwing a floating
   -- window error if we attempt to source without having a non-floating 
   -- buffer open
   vim.cmd('new | setlocal bt=nofile bh=wipe nobl noswapfile nu')
   
   -- source our Session.vim file and ignore the error about closing the
   -- scratch file above so abruptly
   vim.cmd('silent! source Session.vim')
  end
end
```

and that gets assigned in the `setup()` call as follows:

```lua
require("project_nvim").setup { 
  detection_methods = { "pattern" },
  patterns = { ".git", ".svn" },  -- only register versioning roots as projects
  custom_callback = loadSession
}
```

Ideally, I think this could be expanded to allow for custom commands _per project_ but I didn't know if that was realistically possible. It could probably be achieved by passing a table where the key is the name of the project and the value is the function to execute, but I wasn't able to find a way to get the project name from telescope. Additionally, this possible addition would be brittle because two projects could potentially share the same name. I also don't think we can use the `promt_bufnr` because there's not a user-friendly way of really managing that AFAIK.

That said, we could also just pass these responsibilities onto the user to figure out conditionals with their custom callback.

Regardless, this pull request works for me and I think will be of aid to others.

Happy to make any changes or updates as needed!

**UPDATE**: Please see my comment below on how this has changed to allow a callback when closing a project _and_ when opening one.

Cheers,
Jake