### PR TITLE
fix: Ignore invalid file paths

### DIFF
--- a/lua/project_nvim/project.lua
+++ b/lua/project_nvim/project.lua
@@ -232,7 +232,7 @@ function M.on_buf_enter()
   end
 
   local current_dir = vim.fn.expand("%:p:h", true)
-  if path.is_excluded(current_dir) then
+  if not path.exists(current_dir) or path.is_excluded(current_dir) then
     return
   end
 

--- a/lua/project_nvim/utils/path.lua
+++ b/lua/project_nvim/utils/path.lua
@@ -30,4 +30,8 @@ function M.is_excluded(dir)
   return false
 end
 
+function M.exists(path)
+  return vim.fn.empty(vim.fn.glob(path)) == 0
+end
+
 return M


### PR DESCRIPTION
I use [fugitive](https://github.com/tpope/vim-fugitive) as plugin.
When using `:Gdiffsplit` it will create and focus an extra buffer that is called for example (in my particular case) `fugitive:///home/dominik/config/.git//5006169cf7d8d3b97bc1c8e86b3dc9252a30839b/userconf/.config/nvim`.
I also have configured `project.nvim` like this:
```lua
require("project_nvim").setup({
  patterns = M.root_patterns = { "=nvim", "=node_modules", ".git", "_darcs", ".hg", ".bzr", ".svn" },
  detection_methods = { "pattern", "lsp" }
})
```
The `"=nvim"` entry will make `project.nvim` try to set `fugitive:///home/dominik/config/.git//5006169cf7d8d3b97bc1c8e86b3dc9252a30839b/userconf/.config/nvim` as the project root, which fails since this is not a path to an actual file and as a consequence the `:Gdiffsplit` command has no effect.

With this commit i suggest to ignore all files and directories that do not exist and to not try to change the current dir in these cases.