### PR TITLE
changed multiple instances of 'detection_methods' to 'patterns'

### DIFF
--- a/README.md
+++ b/README.md
@@ -132,21 +132,21 @@ for your convenience, I will copy paste them here:
 To specify the root is a certain directory, prefix it with `=`.
 
 ```lua
-detection_methods = { "=src" }
+patterns = { "=src" }
 ```
 
 To specify the root has a certain directory or file (which may be a glob), just
 give the name:
 
 ```lua
-detection_methods = { ".git", "Makefile", "*.sln", "build/env.sh" }
+patterns = { ".git", "Makefile", "*.sln", "build/env.sh" }
 ```
 
 To specify the root has a certain directory as an ancestor (useful for
 excluding directories), prefix it with `^`:
 
 ```lua
-detection_methods = { "^fixtures" }
+patterns = { "^fixtures" }
 ```
 
 To specify the root has a certain directory as its direct ancestor / parent
@@ -154,13 +154,13 @@ To specify the root has a certain directory as its direct ancestor / parent
 `>`:
 
 ```lua
-detection_methods = { ">Latex" }
+patterns = { ">Latex" }
 ```
 
 To exclude a pattern, prefix it with `!`.
 
 ```lua
-detection_methods = { "!.git/worktrees", "!=extras", "!^fixtures", "!build/env.sh" }
+patterns = { "!.git/worktrees", "!=extras", "!^fixtures", "!build/env.sh" }
 ```
 
 List your exclusions before the patterns you do want.


### PR DESCRIPTION
This may be misunderstanding on my part, but I believe the example references to `detection_methods` under the section [Pattern Matching](https://github.com/ahmedkhalf/project.nvim#pattern-matching) were meant to be `patterns`.
(And from my limited experimentation putting those patterns as values of `patterns = {...}` worked, where as doing the same for `detection_methods = {...}` did not.)

Hopefully this is helpful and not just confusion lived aloud. :)