### PR TITLE
Add pyproject.toml in patterns

### DIFF
--- a/lua/project_nvim/config.lua
+++ b/lua/project_nvim/config.lua
@@ -14,7 +14,7 @@ M.defaults = {
 
   -- All the patterns used to detect root dir, when **"pattern"** is in
   -- detection_methods
-  patterns = { ".git", "_darcs", ".hg", ".bzr", ".svn", "Makefile", "package.json" },
+  patterns = { ".git", "_darcs", ".hg", ".bzr", ".svn", "Makefile", "package.json", "pyproject.toml" },
 
   -- Table of lsp clients to ignore by name
   -- eg: { "efm", ... }


### PR DESCRIPTION
like package.json, I don't see a use case where pyproject.toml would no be in root dir.