### PR TITLE
Add `parent` as a detection method

### DIFF
--- a/README.md
+++ b/README.md
@@ -91,10 +91,19 @@ use {
   manual_mode = false,
 
   -- Methods of detecting the root directory. **"lsp"** uses the native neovim
-  -- lsp, while **"pattern"** uses vim-rooter like glob pattern matching. Here
-  -- order matters: if one is not detected, the other is used as fallback. You
-  -- can also delete or rearangne the detection methods.
-  detection_methods = { "lsp", "pattern" },
+  -- lsp, **"pattern"** uses vim-rooter like glob pattern matching, while
+  -- **"parent"** uses the parent directory of the current file. Here order
+  -- matters: if one is not detected, the other is used as fallback. You can
+  -- also delete or rearangne the detection methods.
+  detection_methods = {
+    "lsp",
+    "pattern",
+    -- "parent",
+  },
+
+  -- Don't store root directories detected using these specific methods in the
+  -- project history
+  ignore_history = { "parent" },
 
   -- All the patterns used to detect root dir, when **"pattern"** is in
   -- detection_methods

--- a/lua/project_nvim/config.lua
+++ b/lua/project_nvim/config.lua
@@ -7,10 +7,19 @@ M.defaults = {
   manual_mode = false,
 
   -- Methods of detecting the root directory. **"lsp"** uses the native neovim
-  -- lsp, while **"pattern"** uses vim-rooter like glob pattern matching. Here
-  -- order matters: if one is not detected, the other is used as fallback. You
-  -- can also delete or rearangne the detection methods.
-  detection_methods = { "lsp", "pattern" },
+  -- lsp, **"pattern"** uses vim-rooter like glob pattern matching, while
+  -- **"parent"** uses the parent directory of the current file. Here order
+  -- matters: if one is not detected, the other is used as fallback. You can
+  -- also delete or rearangne the detection methods.
+  detection_methods = {
+    "lsp",
+    "pattern",
+    -- "parent",
+  },
+
+  -- Don't store root directories detected using these specific methods in the
+  -- project history
+  ignore_history = { "parent" },
 
   -- All the patterns used to detect root dir, when **"pattern"** is in
   -- detection_methods

--- a/lua/project_nvim/project.lua
+++ b/lua/project_nvim/project.lua
@@ -40,7 +40,7 @@ function M.find_pattern_root()
   local curr_dir_cache = {}
 
   local function get_parent(path)
-    path = path:match("^(.*)/")
+    path = path:match("^(.*/)[^/]+/?$")
     if path == "" then
       path = "/"
     end

--- a/lua/project_nvim/project.lua
+++ b/lua/project_nvim/project.lua
@@ -171,8 +171,10 @@ end
 
 function M.set_pwd(dir, method)
   if dir ~= nil then
-    M.last_project = dir
-    table.insert(history.session_projects, dir)
+    if not vim.tbl_contains(config.options.ignore_history, method) then
+      M.last_project = dir
+      table.insert(history.session_projects, dir)
+    end
 
     if vim.fn.getcwd() ~= dir then
       vim.api.nvim_set_current_dir(dir)
@@ -200,6 +202,8 @@ function M.get_project_root()
       if root ~= nil then
         return root, method
       end
+    elseif detection_method == "parent" then
+      return vim.fn.expand("%:p:h", true), detection_method
     end
   end
 end


### PR DESCRIPTION
This detection method simply sets the current working directory to the parent directory of the current file. Useful as a fallback when you are dealing with simple and generic projects that `lsp` and `pattern` can't meaningfully detect.
Also, the parent directory regex originally ended up producing results such as `C:` or `D:` on Windows, which `fs_scandir` for some reason interprets as the current working directory. So to fix that, the new regex will always produce paths that ends with a `/` when it successfully finds a parent directory.