### PR TITLE
add fallback_buffer_dir option

### DIFF
--- a/README.md
+++ b/README.md
@@ -115,6 +115,9 @@ use {
   -- directory.
   silent_chdir = true,
 
+  -- Change root directory to the buffer directory if it is outside a project
+  fallback_buffer_dir = false,
+
   -- Path where project.nvim will store the project history for use in
   -- telescope
   datapath = vim.fn.stdpath("data"),

--- a/lua/project_nvim/config.lua
+++ b/lua/project_nvim/config.lua
@@ -31,6 +31,9 @@ M.defaults = {
   -- directory.
   silent_chdir = true,
 
+  -- Change root directory to the buffer directory if it is outside a project
+  fallback_buffer_dir = false,
+
   -- Path where project.nvim will store the project history for use in
   -- telescope
   datapath = vim.fn.stdpath("data"),

--- a/lua/project_nvim/project.lua
+++ b/lua/project_nvim/project.lua
@@ -173,18 +173,21 @@ function M.set_pwd(dir, method)
   if dir ~= nil then
     M.last_project = dir
     table.insert(history.session_projects, dir)
-
-    if vim.fn.getcwd() ~= dir then
-      vim.api.nvim_set_current_dir(dir)
-
-      if config.options.silent_chdir == false then
-        vim.notify("Set CWD to " .. dir .. " using " .. method)
-      end
-    end
-    return true
+  elseif config.options.fallback_buffer_dir then
+    dir = vim.fn.expand("%:p:h", true)
+    method = "buffer directory fallback"
+  else
+    return false
   end
 
-  return false
+  if vim.fn.getcwd() ~= dir then
+    vim.api.nvim_set_current_dir(dir)
+
+    if config.options.silent_chdir == false then
+      vim.notify("Set CWD to " .. dir .. " using " .. method)
+    end
+  end
+  return true
 end
 
 function M.get_project_root()


### PR DESCRIPTION
This adds an option to change the root directory to the buffer directory, if the file is outside of a project. 

I often edit files outside of projects while my cwd is somewhere else. Telescope and nvim-tree can be convinced to open the buffer's directory without changing this plugin, but for `:edit`, `:write` and running shell commands in the same directory there is no alternative.