### PR TITLE
Neovim Session Manager integration to create IDE-like project switching

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,6 +18,8 @@ superior project management.
   - Access your recently opened projects from telescope!
   - Asynchronous file io so it will not slow down vim when reading the history
     file on startup.
+- Neovim Session Manager integration to create IDE-like project switching
+  - Set option `session_autoload = true` and `:Telescope projects` command will navigate you to chosen project's directory and your previously opened buffers will be restored. [Neovim Session Manager](https://github.com/Shatur/neovim-session-manager) need to be installed for this feature.
 - ~~Nvim-tree.lua support/integration~~
   - Please add the following to your config instead:
     ```vim
@@ -124,6 +126,11 @@ use {
   -- Path where project.nvim will store the project history for use in
   -- telescope
   datapath = vim.fn.stdpath("data"),
+
+  -- If plugin 'Shatur/neovim-session-manager' is installed,
+  -- set this option to true if you want to open projects as sessions
+  -- as default action for ":Telescope projects"
+  session_autoload = false,
 }
 ```
 

--- a/lua/project_nvim/config.lua
+++ b/lua/project_nvim/config.lua
@@ -40,6 +40,11 @@ M.defaults = {
   -- Path where project.nvim will store the project history for use in
   -- telescope
   datapath = vim.fn.stdpath("data"),
+
+  -- If plugin 'Shatur/neovim-session-manager' is installed,
+  -- set this option to true if you want to open projects as sessions
+  -- as default action for ":Telescope projects"
+  session_autoload = false,
 }
 
 ---@type ProjectOptions

--- a/lua/telescope/_extensions/projects.lua
+++ b/lua/telescope/_extensions/projects.lua
@@ -61,7 +61,7 @@ local function create_finder()
 end
 
 local function change_working_directory(prompt_bufnr, prompt)
-  local selected_entry = state.get_selected_entry(prompt_bufnr)
+  local selected_entry = state.get_selected_entry()
   if selected_entry == nil then
     actions.close(prompt_bufnr)
     return
@@ -139,7 +139,7 @@ local function recent_project_files(prompt_bufnr)
 end
 
 local function delete_project(prompt_bufnr)
-  local selectedEntry = state.get_selected_entry(prompt_bufnr)
+  local selectedEntry = state.get_selected_entry()
   if selectedEntry == nil then
     actions.close(prompt_bufnr)
     return

--- a/lua/telescope/_extensions/projects.lua
+++ b/lua/telescope/_extensions/projects.lua
@@ -6,6 +6,7 @@ if not has_telescope then
   return
 end
 
+local has_session_manager, manager = pcall(require, "session_manager")
 local finders = require("telescope.finders")
 local pickers = require("telescope.pickers")
 local telescope_config = require("telescope.config").values
@@ -71,7 +72,22 @@ local function change_working_directory(prompt_bufnr, prompt)
   else
     actions.close(prompt_bufnr)
   end
+  -- session_manager will change session if session_autoload is enabled
+  local session_switch = config.options.session_autoload
+  if session_switch and not has_session_manager then
+    print("Warning: session autoloading is enabled, but neovim-session-manager in not installed!")
+    print("Consider to install 'Shatur/neovim-session-manager' or")
+    print("change project.nvim option ('session_autoload' = false) to remove this message")
+    session_switch = false
+  end
+  if session_switch then
+    -- save current session before switch project
+    manager.save_current_session()
+  end
   local cd_successful = project.set_pwd(project_path, "telescope")
+  if session_switch and cd_successful then
+    manager.load_current_dir_session(false)
+  end
   return project_path, cd_successful
 end
 
@@ -164,9 +180,16 @@ local function projects(opts)
       map("i", "<c-r>", recent_project_files)
       map("i", "<c-w>", change_working_directory)
 
-      local on_project_selected = function()
-        find_project_files(prompt_bufnr)
-      end
+	  local on_project_selected
+	  if config.options.session_autoload and has_session_manager then
+		  on_project_selected = function()
+			  change_working_directory(prompt_bufnr, false)
+		  end
+	  else
+		  on_project_selected = function()
+			  find_project_files(prompt_bufnr)
+		  end
+	  end
       actions.select_default:replace(on_project_selected)
       return true
     end,

--- a/lua/telescope/_extensions/projects.lua
+++ b/lua/telescope/_extensions/projects.lua
@@ -81,8 +81,9 @@ local function change_working_directory(prompt_bufnr, prompt)
     session_switch = false
   end
   if session_switch then
-    -- save current session before switch project
-    manager.save_current_session()
+	-- before switch project
+    -- save current session based on settings
+    manager.autosave_session()
   end
   local cd_successful = project.set_pwd(project_path, "telescope")
   if session_switch and cd_successful then


### PR DESCRIPTION
## Goal: create IDE-like project switching with saved sessions

### Demo how it works in this PR:
I'm switching projects by using `:Telescope projects` (i mapped this command to `<leader>p` for me, but only in my personal configuration). 

As you can see on the video, opened tabs depends on which project is opened and everything auto-saving when switching projects. 

[rec.webm](https://user-images.githubusercontent.com/3100053/201075165-8ad9ccf6-d172-474b-9074-b72b08ec2d58.webm)

Before merge this PR, you can test it by installing from packer:
```
use({
"coffebar/project.nvim",
branch = "session-manager",
config = function()
	require("project_nvim").setup({
		session_autoload = true,
		silent_chdir = false,
	})
end,
})

-- session manager
use("Shatur/neovim-session-manager")
```

Not sure if `require("session_manager").setup({...` is required by neovim-session-manager, it seems not, but i'm using configuration options for that plugin.

## How it NOT breaking things

With default configuration it will not bring any additional features. To add integration user have to enable a new option "session_autoload". 
If this option will be enabled, but session manager plugin is not installed, user will see warning message from this code:
```lua
print("Warning: session autoloading is enabled, but neovim-session-manager in not installed!")
print("Consider to install 'Shatur/neovim-session-manager' or")
print("change project.nvim option ('session_autoload' = false) to remove this message")
```
When plugin is installed and option is enabled, project selection can be done in 3 ways:
- by session manager itself (with it's autoload_mode option)
- `:Telescope projects` type project keywords and press `<CR>`
- `:Telescope projects` type project keywords and press `<C-w>`

`<C-d>` will work for delete project from history as usual.

## Important

When session manager is installed, using  `find_project_files` **is not recommended**! Opening individual files will make projects.nvim to change current directory, and session manager will automatically overwrite saved sessions with mess from individual files from different projects.

Therefore, using these two plugins together as it was before this PR -  is a bad idea. This should  fix problem. 

### Testing

I have tested only for 2 days by using this branch in my Neovim setup. Testing from different configs and workflows are welcome.

## Known issues 
- `<C-f>` will switch project, so find_project_files is totally disabled with session_autoload=true.
- `<C-b>` leads to error for me: telescope.builtin.file_browser is nil. I believe this is related with telescope update



