### PR TITLE
Expose API method get_project_root

### DIFF
--- a/README.md
+++ b/README.md
@@ -206,6 +206,17 @@ local project_nvim = require("project_nvim")
 local recent_projects = project_nvim.get_recent_projects()
 
 print(vim.inspect(recent_projects))
+# Prints: { "/path/to/a/project", "/path/to/another-project" }
+```
+
+Get project root path:
+
+```lua
+local project_nvim = require("project_nvim")
+local project_path, method = project_nvim.get_project_root()
+
+print(project_path, method)
+# Prints: "/path/to/a/project" "pattern .git"
 ```
 
 ## 🤝 Contributing

--- a/lua/project_nvim/init.lua
+++ b/lua/project_nvim/init.lua
@@ -1,8 +1,10 @@
 local config = require("project_nvim.config")
+local project = require("project_nvim.project")
 local history = require("project_nvim.utils.history")
 local M = {}
 
 M.setup = config.setup
 M.get_recent_projects = history.get_recent_projects
+M.get_project_root = project.get_project_root
 
 return M


### PR DESCRIPTION
There's a handy API you have `get_project_root`, which returns the root project path for any given file of a project and currently it's not exposed.

It's useful to me since I store todos, notes, etc. for each git repository I work with in a separate directory and this method is useful in organizing those files and bringing them up quickly.