### PR TITLE
feat: name/path transforms using custom user functions

### DIFF
--- a/README.md
+++ b/README.md
@@ -121,6 +121,17 @@ use {
   -- * win
   scope_chdir = 'global',
 
+  -- Custom callback to allow the name to be altered before display.
+  -- Displays the tail component of the path by default.
+  -- * function(path) return vim.fn.fnamemodify(path, ":t") end
+  transform_name = nil,
+
+  -- Custom callback to allow the path to be altered before display.
+  -- Displays an absolute path by default.
+  -- Ex: to shorten /home/me/projects/my-project into ~/projects/my-project, you can use:
+  -- * function(path) return vim.fn.fnamemodify(path, ":~") end
+  transform_path = nil,
+
   -- Path where project.nvim will store the project history for use in
   -- telescope
   datapath = vim.fn.stdpath("data"),

--- a/lua/project_nvim/config.lua
+++ b/lua/project_nvim/config.lua
@@ -37,6 +37,17 @@ M.defaults = {
   -- * win
   scope_chdir = 'global',
 
+  -- Custom callback to allow the name to be altered before display.
+  -- Displays the tail component of the path by default.
+  -- * function(path) return vim.fn.fnamemodify(path, ":t") end
+  transform_name = nil,
+
+  -- Custom callback to allow the path to be altered before display.
+  -- Displays an absolute path by default.
+  -- Ex: to shorten /home/me/projects/my-project into ~/projects/my-project, you can use:
+  -- * function(path) return vim.fn.fnamemodify(path, ":~") end
+  transform_path = nil,
+
   -- Path where project.nvim will store the project history for use in
   -- telescope
   datapath = vim.fn.stdpath("data"),

--- a/lua/telescope/_extensions/projects.lua
+++ b/lua/telescope/_extensions/projects.lua
@@ -42,16 +42,27 @@ local function create_finder()
   })
 
   local function make_display(entry)
-    return displayer({ entry.name, { entry.value, "Comment" } })
+    return displayer({ entry.name, { entry.display_path, "Comment" } })
   end
 
   return finders.new_table({
     results = results,
     entry_maker = function(entry)
       local name = vim.fn.fnamemodify(entry, ":t")
+      local display_path = entry
+
+      if config.options.transform_name ~= nil then
+        name = config.options.transform_name(entry)
+      end
+
+      if config.options.transform_path ~= nil then
+        display_path = config.options.transform_path(entry)
+      end
+
       return {
         display = make_display,
         name = name,
+        display_path = display_path,
         value = entry,
         ordinal = name .. " " .. entry,
       }


### PR DESCRIPTION
Examples of what it might look like after:

![image](https://github.com/ahmedkhalf/project.nvim/assets/9924643/74cd22bc-c0c2-43fa-9931-c38bc9a76fb3)

Config:
```lua
lvim.builtin.project.transform_path = function(path)
	return vim.fn.fnamemodify(path, ":~")
end

lvim.builtin.project.transform_name = function(path)
	return "[client] " .. vim.fn.fnamemodify(path, ":t")
end
```

Ideally, "client" would match on some base known path (e.g. a base project name or client name if there are nested projects under that), and the name would point to a submodule for that project. Sometimes I need to switch from the base project CWD to the submodule, for various reasons, and it would be nice to have that clear separation, and to reduce the noise potentially shown in the path.
```
[client A] submodule X     ~/projects/client A/some/path/to/submodule X
[client B] submodule X     ~/projects/client B/some/path/to/submodule X
```

Closes #124

