### PR TITLE
Support pinning working directory on per buffer or per window basis

### DIFF
--- a/README.md
+++ b/README.md
@@ -111,6 +111,14 @@ use {
   -- Show hidden files in telescope
   show_hidden = false,
 
+  -- Retain directory settings for buffer. Override detection method.
+  -- If directory was changed, the buffer will retain the same directory
+  enable_buffer_local_dir = false,
+
+  -- Retain directory settings for window. Override detection method.
+  -- All buffers opened on the window will retain the directory
+  enable_window_local_dir = false,
+
   -- When set to false, you will get a message when project.nvim changes your
   -- directory.
   silent_chdir = true,
@@ -170,6 +178,13 @@ patterns = { "!.git/worktrees", "!=extras", "!^fixtures", "!build/env.sh" }
 ```
 
 List your exclusions before the patterns you do want.
+
+### CWD scope and Window/Buffer Local directories
+By default project.nvim sets the CWD to root of the project as explained above.
+The directory being set scope can be set to tab/global/ as controlled by scope_chdir.
+Occasionally, it is desirable to have a certain buffer always start in a specific directory. If this is needed, **enable_buffer_local_dir** can help you with it. With this option set, when user changes the working directory using "cd" while editing a buffer, the buffer will always stay in that directory all the time. All other buffers will continue to use the default working directory.
+Similarly, a given window could be pinned to always use same directory. Any bufferes opened in that that window will always be opened in that directory. This is useful when sometimes the user uses "gf" to open files relative to that directory. To enable this, use **enable_window_local_dir** option.
+NOTE: If both options are enabled, buffer local directory will be used over if window local diretory setting.
 
 ### Telescope Integration
 

--- a/README.md
+++ b/README.md
@@ -182,9 +182,12 @@ List your exclusions before the patterns you do want.
 ### CWD scope and Window/Buffer Local directories
 By default project.nvim sets the CWD to root of the project as explained above.
 The directory being set scope can be set to tab/global/ as controlled by scope_chdir.
-Occasionally, it is desirable to have a certain buffer always start in a specific directory. If this is needed, **enable_buffer_local_dir** can help you with it. With this option set, when user changes the working directory using "cd" while editing a buffer, the buffer will always stay in that directory all the time. All other buffers will continue to use the default working directory.
+
+Occasionally, it is desirable to pin certain buffer to a specific directory. **enable_buffer_local_dir** can help you with it. With this option set, when user changes the working directory using "cd" while editing a buffer, the buffer will always stay in that directory all the time. All other buffers will continue to use the default working directory.
+
 Similarly, a given window could be pinned to always use same directory. Any bufferes opened in that that window will always be opened in that directory. This is useful when sometimes the user uses "gf" to open files relative to that directory. To enable this, use **enable_window_local_dir** option.
-NOTE: If both options are enabled, buffer local directory will be used over if window local diretory setting.
+
+NOTE: When both options are enabled, buffer local directory will be used over if window local diretory setting.
 
 ### Telescope Integration
 

--- a/lua/project_nvim/config.lua
+++ b/lua/project_nvim/config.lua
@@ -27,6 +27,14 @@ M.defaults = {
   -- Show hidden files in telescope
   show_hidden = false,
 
+  -- Retain directory settings for buffer. Override detection method.
+  -- If directory was changed, the buffer will retain the same directory
+  enable_buffer_local_dir = false,
+
+  -- Retain directory settings for window. Override detection method.
+  -- All buffers opened on the window will retain the directory
+  enable_window_local_dir = false,
+
   -- When set to false, you will get a message when project.nvim changes your
   -- directory.
   silent_chdir = true,

--- a/lua/project_nvim/project.lua
+++ b/lua/project_nvim/project.lua
@@ -4,6 +4,7 @@ local glob = require("project_nvim.utils.globtopattern")
 local path = require("project_nvim.utils.path")
 local uv = vim.loop
 local M = {}
+local local_dirs = {}
 
 -- Internal states
 M.attached_lsp = false
@@ -169,6 +170,16 @@ function M.attach_to_lsp()
   M.attached_lsp = true
 end
 
+local function get_buf_name()
+    if config.options.enable_buffer_local_dir == true then
+      return 'b' .. vim.fn.bufnr()
+    end
+    if config.options.enable_window_local_dir == true then
+      return 'w' .. vim.fn.win_getid()
+    end
+    return nil
+end
+
 function M.set_pwd(dir, method)
   if dir ~= nil then
     M.last_project = dir
@@ -187,7 +198,13 @@ function M.set_pwd(dir, method)
       end
 
       if config.options.silent_chdir == false then
-        vim.notify("Set CWD to " .. dir .. " using " .. method)
+        vim.notify("buf " .. vim.fn.bufnr() .. ": Set CWD to " .. dir .. " using " .. method)
+      end
+
+      -- handle set_pwd from Telescope/ other plugins
+      if config.options.enable_window_local_dir == true and method ~= 'local' then
+        -- local_dirs['w' .. vim.fn.win_getid()] = nil
+        local_dirs[get_buf_name()] = nil
       end
     end
     return true
@@ -231,6 +248,31 @@ function M.is_file()
   return true
 end
 
+function M.on_buf_leave()
+  if not M.is_file() then
+    return
+  end
+
+  if config.options.enable_buffer_local_dir == false and config.options.enable_window_local_dir == false then
+    return
+  end
+
+  local current_dir = vim.fn.expand("%:p:h", true)
+  if not path.exists(current_dir) or path.is_excluded(current_dir) then
+    return
+  end
+
+  local new_dir = vim.fn.getcwd(vim.fn.win_getid())
+  local root, _ = M.get_project_root()
+  if new_dir ~= root then
+     -- vim.notify("Insert:buf " .. vim.fn.bufnr() .. ": CWD (" .. new_dir .. "). root(" .. root .. ")." .. vim.inspect(local_dirs))
+    local_dirs[get_buf_name()] = new_dir
+  else
+    -- vim.notify("default root. before removing entry " .. vim.fn.bufnr() .. ". old: " .. vim.inspect(local_dirs))
+    local_dirs[get_buf_name()] = nil
+  end
+end
+
 function M.on_buf_enter()
   if vim.v.vim_did_enter == 0 then
     return
@@ -245,8 +287,23 @@ function M.on_buf_enter()
     return
   end
 
-  local root, method = M.get_project_root()
-  M.set_pwd(root, method)
+  -- vim.notify("buf_enter: buf# " .. vim.fn.bufnr() .. vim.inspect(local_dirs))
+  if local_dirs[get_buf_name()] then
+    -- vim.notify('Found window specific dir ' .. local_dirs[vim.fn.bufnr()])
+    M.set_pwd(local_dirs[get_buf_name()], "local")
+  else
+    local root, method = M.get_project_root()
+    M.set_pwd(root, method)
+  end
+  -- if local_dirs['b' .. vim.fn.bufnr()] then
+  --   -- vim.notify('Found window specific dir ' .. local_dirs[vim.fn.bufnr()])
+  --   M.set_pwd(local_dirs['b' .. vim.fn.bufnr()], "local")
+  -- elseif local_dirs['w' .. vim.fn.win_getid()] then
+  --   M.set_pwd(local_dirs['w' .. vim.fn.win_getid()], "local")
+  -- else
+  --   local root, method = M.get_project_root()
+  --   M.set_pwd(root, method)
+  -- end
 end
 
 function M.add_project_manually()
@@ -258,6 +315,7 @@ function M.init()
   local autocmds = {}
   if not config.options.manual_mode then
     autocmds[#autocmds + 1] = 'autocmd VimEnter,BufEnter * ++nested lua require("project_nvim.project").on_buf_enter()'
+    autocmds[#autocmds + 1] = 'autocmd VimLeave,BufLeave * ++nested lua require("project_nvim.project").on_buf_leave()'
 
     if vim.tbl_contains(config.options.detection_methods, "lsp") then
       M.attach_to_lsp()

--- a/lua/project_nvim/project.lua
+++ b/lua/project_nvim/project.lua
@@ -203,7 +203,6 @@ function M.set_pwd(dir, method)
 
       -- handle set_pwd from Telescope/ other plugins
       if config.options.enable_window_local_dir == true and method ~= 'local' then
-        -- local_dirs['w' .. vim.fn.win_getid()] = nil
         local_dirs[get_buf_name()] = nil
       end
     end
@@ -265,10 +264,8 @@ function M.on_buf_leave()
   local new_dir = vim.fn.getcwd(vim.fn.win_getid())
   local root, _ = M.get_project_root()
   if new_dir ~= root then
-     -- vim.notify("Insert:buf " .. vim.fn.bufnr() .. ": CWD (" .. new_dir .. "). root(" .. root .. ")." .. vim.inspect(local_dirs))
     local_dirs[get_buf_name()] = new_dir
   else
-    -- vim.notify("default root. before removing entry " .. vim.fn.bufnr() .. ". old: " .. vim.inspect(local_dirs))
     local_dirs[get_buf_name()] = nil
   end
 end
@@ -287,23 +284,12 @@ function M.on_buf_enter()
     return
   end
 
-  -- vim.notify("buf_enter: buf# " .. vim.fn.bufnr() .. vim.inspect(local_dirs))
   if local_dirs[get_buf_name()] then
-    -- vim.notify('Found window specific dir ' .. local_dirs[vim.fn.bufnr()])
     M.set_pwd(local_dirs[get_buf_name()], "local")
   else
     local root, method = M.get_project_root()
     M.set_pwd(root, method)
   end
-  -- if local_dirs['b' .. vim.fn.bufnr()] then
-  --   -- vim.notify('Found window specific dir ' .. local_dirs[vim.fn.bufnr()])
-  --   M.set_pwd(local_dirs['b' .. vim.fn.bufnr()], "local")
-  -- elseif local_dirs['w' .. vim.fn.win_getid()] then
-  --   M.set_pwd(local_dirs['w' .. vim.fn.win_getid()], "local")
-  -- else
-  --   local root, method = M.get_project_root()
-  --   M.set_pwd(root, method)
-  -- end
 end
 
 function M.add_project_manually()


### PR DESCRIPTION
This PR allows user to set the working directory and project.nvim will remember the setting.
This is useful when browsing large projects.

Per buffer: enable_buffer_local_dir
  - the buffer with different directory will always open in that directory.

Per window: enable_window_local_dir
- all files opened in that window will be have the directory that it was set.

