### PR TITLE
feat(exclude-from-chdir) Add exclude_chdir

### DIFF
--- a/.selene-schema.yml
+++ b/.selene-schema.yml
@@ -1,0 +1,45 @@
+---
+base: lua51
+name: .selene-schema
+globals:
+  after_each:
+    args:
+      - type: function
+  assert.equals:
+    args:
+      - type: any
+      - type: any
+      - required: false
+        type: any
+  assert.is_not:
+    any: true
+  assert.same:
+    args:
+      - type: any
+      - type: any
+  assert.spy:
+    args:
+      - type: any
+  assert.stub:
+    args:
+      - type: any
+  assert.truthy:
+    args:
+      - type: any
+  before_each:
+    args:
+      - type: function
+  describe:
+    args:
+      - type: string
+      - type: function
+  it:
+    args:
+      - type: string
+      - type: function
+  jit:
+    any: true
+  vim:
+    any: true
+  base:
+    any: true

--- a/README.md
+++ b/README.md
@@ -125,11 +125,11 @@ use {
   -- * win
   scope_chdir = 'global',
 
-  -- Don't chdir for specific filetypes
-  exclude_filetype_chdir = {"", "OverseerList",},
-
-  -- Don't chdir for specific buftypes
-  exclude_buftype_chdir = {"", "terminal"},
+  -- Don't chdir for certain buffers
+  exclude_chdir = {
+    filetype = {"", "OverseerList", "alpha"},
+    buftype = {"nofile", "terminal"},
+  },
 
   -- Path where project.nvim will store the project history for use in
   -- telescope

--- a/README.md
+++ b/README.md
@@ -1,3 +1,7 @@
+## Changes over the original project
+* Nvim 0.10 and 0.11 support.
+* Ability to exclude buffers from autocd.
+
 # 🗃️ project.nvim
 
 **project.nvim** is an all in one neovim plugin written in lua that provides
@@ -7,7 +11,7 @@ superior project management.
 
 ## ⚡ Requirements
 
-- Neovim >= 0.5.0
+- Neovim >= 0.10.0
 
 ## ✨ Features
 
@@ -218,3 +222,11 @@ print(vim.inspect(recent_projects))
 
 - All pull requests are welcome.
 - If you encounter bugs please open an issue.
+
+## TODOS
+In the future i'd like to divide this plugin into two plugins:
+
+* autocd.nvim
+* project.nvim 
+
+As that's two different cases of use.

--- a/README.md
+++ b/README.md
@@ -222,11 +222,3 @@ print(vim.inspect(recent_projects))
 
 - All pull requests are welcome.
 - If you encounter bugs please open an issue.
-
-## TODOS
-In the future i'd like to divide this plugin into two plugins:
-
-* autocd.nvim
-* project.nvim 
-
-As that's two different cases of use.

--- a/README.md
+++ b/README.md
@@ -121,6 +121,12 @@ use {
   -- * win
   scope_chdir = 'global',
 
+  -- Don't chdir for specific filetypes
+  exclude_filetype_chdir = {"", "OverseerList",},
+
+  -- Don't chdir for specific buftypes
+  exclude_buftype_chdir = {"", "terminal"},
+
   -- Path where project.nvim will store the project history for use in
   -- telescope
   datapath = vim.fn.stdpath("data"),

--- a/lua/project_nvim/config.lua
+++ b/lua/project_nvim/config.lua
@@ -41,7 +41,7 @@ M.defaults = {
   exclude_filetype_chdir = {"", "OverseerList"},
 
   -- Don't chdir for specific buftypes
-  exclude_buftype_chdir = {"", "terminal"},
+  exclude_buftype_chdir = {"nofile", "terminal"},
 
   -- Path where project.nvim will store the project history for use in
   -- telescope

--- a/lua/project_nvim/config.lua
+++ b/lua/project_nvim/config.lua
@@ -37,7 +37,7 @@ M.defaults = {
   -- * win
   scope_chdir = 'global',
 
-  -- Don't chdir for specific filetypes
+  -- Don't chdir for certain buffers
   exclude_chdir = {
     filetype = {"", "OverseerList", "alpha"},
     buftype = {"nofile", "terminal"},

--- a/lua/project_nvim/config.lua
+++ b/lua/project_nvim/config.lua
@@ -38,7 +38,7 @@ M.defaults = {
   scope_chdir = 'global',
 
   -- Don't chdir for specific filetypes
-  exclude_filetype_chdir = {"", "OverseerList"},
+  exclude_filetype_chdir = {"", "OverseerList", "alpha"},
 
   -- Don't chdir for specific buftypes
   exclude_buftype_chdir = {"nofile", "terminal"},

--- a/lua/project_nvim/config.lua
+++ b/lua/project_nvim/config.lua
@@ -38,10 +38,10 @@ M.defaults = {
   scope_chdir = 'global',
 
   -- Don't chdir for specific filetypes
-  exclude_filetype_chdir = {"", "OverseerList", "alpha"},
-
-  -- Don't chdir for specific buftypes
-  exclude_buftype_chdir = {"nofile", "terminal"},
+  exclude_chdir = {
+    filetype = {"", "OverseerList", "alpha"},
+    buftype = {"nofile", "terminal"},
+  },
 
   -- Path where project.nvim will store the project history for use in
   -- telescope

--- a/lua/project_nvim/config.lua
+++ b/lua/project_nvim/config.lua
@@ -37,11 +37,11 @@ M.defaults = {
   -- * win
   scope_chdir = 'global',
 
-  -- Don't chdir for specific filetypes
-  exclude_filetype_chdir = {"", "OverseerList"},
-
-  -- Don't chdir for specific buftypes
-  exclude_buftype_chdir = {"", "terminal"},
+  -- Don't chdir for certain buffers
+  exclude_chdir = {
+    filetype = {"", "OverseerList", "alpha"},
+    buftype = {"nofile", "terminal"},
+  },
 
   -- Path where project.nvim will store the project history for use in
   -- telescope

--- a/lua/project_nvim/config.lua
+++ b/lua/project_nvim/config.lua
@@ -37,6 +37,12 @@ M.defaults = {
   -- * win
   scope_chdir = 'global',
 
+  -- Don't chdir for specific filetypes
+  exclude_filetype_chdir = {"", "OverseerList"},
+
+  -- Don't chdir for specific buftypes
+  exclude_buftype_chdir = {"", "terminal"},
+
   -- Path where project.nvim will store the project history for use in
   -- telescope
   datapath = vim.fn.stdpath("data"),

--- a/lua/project_nvim/project.lua
+++ b/lua/project_nvim/project.lua
@@ -2,7 +2,6 @@ local config = require("project_nvim.config")
 local history = require("project_nvim.utils.history")
 local glob = require("project_nvim.utils.globtopattern")
 local path = require("project_nvim.utils.path")
-local uv = vim.loop
 local M = {}
 
 -- Internal states
@@ -12,8 +11,8 @@ M.last_project = nil
 function M.find_lsp_root()
   -- Get lsp client for current buffer
   -- Returns nil or string
-  local buf_ft = vim.api.nvim_buf_get_option(0, "filetype")
-  local clients = vim.lsp.buf_get_clients()
+  local buf_ft = vim.bo.filetype
+  local clients = vim.lsp.get_clients()
   if next(clients) == nil then
     return nil
   end
@@ -51,13 +50,13 @@ function M.find_pattern_root()
     last_dir_cache = file_dir
     curr_dir_cache = {}
 
-    local dir = uv.fs_scandir(file_dir)
+    local dir = vim.uv.fs_scandir(file_dir)
     if dir == nil then
       return
     end
 
     while true do
-      local file = uv.fs_scandir_next(dir)
+      local file = vim.uv.fs_scandir_next(dir)
       if file == nil then
         return
       end

--- a/lua/project_nvim/project.lua
+++ b/lua/project_nvim/project.lua
@@ -232,12 +232,12 @@ end
 
 function M.on_buf_enter()
   -- if filetype is excluded, return
-  for _, filetype in pairs(config.options.exclude_filetype_chdir) do
+  for _, filetype in pairs(config.options.exclude_chdir.filetype) do
     if filetype == vim.bo.filetype then return end
   end
 
   -- if buftype is excluded, return
-  for _, buftype in pairs(config.options.exclude_buftype_chdir) do
+  for _, buftype in pairs(config.options.exclude_chdir.buftype) do
     if vim.bo.buftype ~= "" and buftype == vim.bo.buftype then return end
   end
 

--- a/lua/project_nvim/project.lua
+++ b/lua/project_nvim/project.lua
@@ -239,7 +239,7 @@ function M.on_buf_enter()
 
   -- if buftype is excluded, return
   for _, buftype in pairs(config.options.exclude_buftype_chdir) do
-    if buftype == vim.bo.buftype then return end
+    if vim.bo.buftype ~= "" and buftype == vim.bo.buftype then return end
   end
 
   if vim.v.vim_did_enter == 0 then
@@ -267,7 +267,7 @@ end
 function M.init()
   local autocmds = {}
   if not config.options.manual_mode then
-    autocmds[#autocmds + 1] = 'autocmd VimEnter,BufEnter * ++nested lua require("project_nvim.project").on_buf_enter()'
+    autocmds[#autocmds + 1] = 'autocmd BufReadPost * ++nested lua require("project_nvim.project").on_buf_enter()'
 
     if vim.tbl_contains(config.options.detection_methods, "lsp") then
       M.attach_to_lsp()

--- a/lua/project_nvim/project.lua
+++ b/lua/project_nvim/project.lua
@@ -232,6 +232,16 @@ function M.is_file()
 end
 
 function M.on_buf_enter()
+  -- if filetype is excluded, return
+  for _, filetype in pairs(config.options.exclude_filetype_chdir) do
+    if filetype == vim.bo.filetype then return end
+  end
+
+  -- if buftype is excluded, return
+  for _, buftype in pairs(config.options.exclude_buftype_chdir) do
+    if buftype == vim.bo.buftype then return end
+  end
+
   if vim.v.vim_did_enter == 0 then
     return
   end

--- a/lua/project_nvim/utils/history.lua
+++ b/lua/project_nvim/utils/history.lua
@@ -1,5 +1,4 @@
 local path = require("project_nvim.utils.path")
-local uv = vim.loop
 local M = {}
 local is_windows = vim.fn.has('win32') or vim.fn.has('wsl')
 
@@ -10,16 +9,16 @@ M.has_watch_setup = false
 local function open_history(mode, callback)
   if callback ~= nil then -- async
     path.create_scaffolding(function(_, _)
-      uv.fs_open(path.historyfile, mode, 438, callback)
+      vim.uv.fs_open(path.historyfile, mode, 438, callback)
     end)
   else -- sync
     path.create_scaffolding()
-    return uv.fs_open(path.historyfile, mode, 438)
+    return vim.uv.fs_open(path.historyfile, mode, 438)
   end
 end
 
 local function dir_exists(dir)
-  local stat = uv.fs_stat(dir)
+  local stat = vim.uv.fs_stat(dir)
   if stat ~= nil and stat.type == "directory" then
     return true
   end
@@ -85,7 +84,7 @@ local function setup_watch()
   -- Only runs once
   if M.has_watch_setup == false then
     M.has_watch_setup = true
-    local event = uv.new_fs_event()
+    local event = vim.uv.new_fs_event()
     if event == nil then
       return
     end
@@ -105,10 +104,10 @@ function M.read_projects_from_history()
   open_history("r", function(_, fd)
     setup_watch()
     if fd ~= nil then
-      uv.fs_fstat(fd, function(_, stat)
+      vim.uv.fs_fstat(fd, function(_, stat)
         if stat ~= nil then
-          uv.fs_read(fd, stat.size, -1, function(_, data)
-            uv.fs_close(fd, function(_, _) end)
+          vim.uv.fs_read(fd, stat.size, -1, function(_, data)
+            vim.uv.fs_close(fd, function(_, _) end)
             deserialize_history(data)
           end)
         end
@@ -170,8 +169,8 @@ function M.write_projects_to_history()
     end
 
     -- Write string out to file and close
-    uv.fs_write(file, out, -1)
-    uv.fs_close(file)
+    vim.uv.fs_write(file, out, -1)
+    vim.uv.fs_close(file)
   end
 end
 

--- a/lua/project_nvim/utils/path.lua
+++ b/lua/project_nvim/utils/path.lua
@@ -1,5 +1,4 @@
 local config = require("project_nvim.config")
-local uv = vim.loop
 local M = {}
 
 M.datapath = vim.fn.stdpath("data") -- directory
@@ -14,9 +13,9 @@ end
 
 function M.create_scaffolding(callback)
   if callback ~= nil then -- async
-    uv.fs_mkdir(M.projectpath, 448, callback)
+    vim.uv.fs_mkdir(M.projectpath, 448, callback)
   else -- sync
-    uv.fs_mkdir(M.projectpath, 448)
+    vim.uv.fs_mkdir(M.projectpath, 448)
   end
 end
 

--- a/selene.toml
+++ b/selene.toml
@@ -1,0 +1,7 @@
+std=".selene-schema"
+
+[lints]
+global_usage = "allow"
+mixed_table = "allow"
+multiple_statements = "allow"
+shadowing = "warn"


### PR DESCRIPTION
## New options added

```lua
-- Don't chdir for certain buffers
exclude_chdir = {
  filetype = {"", "OverseerList", "alpha"},
  buftype = {"nofile", "terminal"},
},
```

This  allow users to exclude certain plugins from triggering chdir.

## Example case of use
I like to use `manual_mode = false` to auto chdir. But I don't want it to auto chdir to ~/ when opening [compiler.nvim](https://github.com/Zeioth/compiler.nvim) / [Overseer](https://github.com/stevearc/overseer.nvim).