### PR TITLE
Allow customization of getting the current directory for find_pattern_root

### DIFF
--- a/README.md
+++ b/README.md
@@ -121,6 +121,14 @@ use {
   -- * win
   scope_chdir = 'global',
 
+  -- Function to get current directory
+  -- This is used by `find_pattern_root` to get the directory of the current buffer. For buffers like oil.nvim, the
+  -- usual vim.fn.expand will not work, since the it returns a URI instead of a path. For buffers like this, you can
+  -- customize how project.nvim obtains the current dir.
+  get_current_dir_fn = function()
+    return vim.fn.expand("%:p:h", true)
+  end,
+
   -- Path where project.nvim will store the project history for use in
   -- telescope
   datapath = vim.fn.stdpath("data"),

--- a/lua/project_nvim/config.lua
+++ b/lua/project_nvim/config.lua
@@ -35,7 +35,12 @@ M.defaults = {
   -- * global (default)
   -- * tab
   -- * win
-  scope_chdir = 'global',
+  scope_chdir = "global",
+
+  -- Function to get current directory
+  get_current_dir_fn = function()
+    return vim.fn.expand("%:p:h", true)
+  end,
 
   -- Path where project.nvim will store the project history for use in
   -- telescope

--- a/lua/project_nvim/config.lua
+++ b/lua/project_nvim/config.lua
@@ -38,6 +38,9 @@ M.defaults = {
   scope_chdir = "global",
 
   -- Function to get current directory
+  -- This is used by `find_pattern_root` to get the directory of the current buffer. For buffers like oil.nvim, the
+  -- usual vim.fn.expand will not work, since the it returns a URI instead of a path. For buffers like this, you can
+  -- customize how project.nvim obtains the current dir.
   get_current_dir_fn = function()
     return vim.fn.expand("%:p:h", true)
   end,

--- a/lua/project_nvim/project.lua
+++ b/lua/project_nvim/project.lua
@@ -31,7 +31,7 @@ function M.find_lsp_root()
 end
 
 function M.find_pattern_root()
-  local search_dir = vim.fn.expand("%:p:h", true)
+  local search_dir = config.options.get_current_dir_fn()
   if vim.fn.has("win32") > 0 then
     search_dir = search_dir:gsub("\\", "/")
   end
@@ -176,12 +176,12 @@ function M.set_pwd(dir, method)
 
     if vim.fn.getcwd() ~= dir then
       local scope_chdir = config.options.scope_chdir
-      if scope_chdir == 'global' then
+      if scope_chdir == "global" then
         vim.api.nvim_set_current_dir(dir)
-      elseif scope_chdir == 'tab' then
-        vim.cmd('tcd ' .. dir)
-      elseif scope_chdir == 'win' then
-        vim.cmd('lcd ' .. dir)
+      elseif scope_chdir == "tab" then
+        vim.cmd("tcd " .. dir)
+      elseif scope_chdir == "win" then
+        vim.cmd("lcd " .. dir)
       else
         return
       end
@@ -251,7 +251,7 @@ end
 
 function M.add_project_manually()
   local current_dir = vim.fn.expand("%:p:h", true)
-  M.set_pwd(current_dir, 'manual')
+  M.set_pwd(current_dir, "manual")
 end
 
 function M.init()


### PR DESCRIPTION
Allow customization of the method that `find_pattern_root` obtains the current working directory.

Right now it uses `vim.fn.expand("%:p:h", true)`, but this does not work for all buffer types (for instance, it doesn't work for oil.nvim, because `vim.fn.expand` returns a URI and not the local file path).

An example of usage for oil.nvim (with lazy.nvim):

```lua
  {
    "ahmedkhalf/project.nvim",
    config = function()
      require("project_nvim").setup({
        manual_mode = false,
        silent_chdir = true,
        detection_methods = { "pattern", "lsp" },
        pattern_get_current_dir_fn = function()
          local status, oil = pcall(require, "oil")

          if status then
            local dir = oil.get_current_dir()

            if dir ~= nil then
              return dir
            end
          end
          return vim.fn.expand("%:p:h", true)
        end,
        show_hidden = false,
        datapath = vim.fn.stdpath("data"),
      })

      utils.on_load("telescope.nvim", function()
        require("telescope").load_extension("projects")
      end)
    end,
  },
```

The default setting remains as `vim.vn.expand("%:p:h")`, so functionality will be the same for anyone that doesn't configure a `pattern_get_current_dir_fn`.
