### PR TITLE
feat: Add get_current_project() API

### DIFF
--- a/README.md
+++ b/README.md
@@ -208,6 +208,14 @@ local recent_projects = project_nvim.get_recent_projects()
 print(vim.inspect(recent_projects))
 ```
 
+Get the project corresponding to the currently active buffer:
+
+```lua
+local project_nvim = require("project_nvim")
+local current_project = project_nvim.get_current_project()
+print(current_project)
+```
+
 ## 🤝 Contributing
 
 - All pull requests are welcome.

--- a/lua/project_nvim/init.lua
+++ b/lua/project_nvim/init.lua
@@ -5,6 +5,6 @@ local M = {}
 
 M.setup = config.setup
 M.get_recent_projects = history.get_recent_projects
-M.get_current_project = project.get_project_root
+M.get_current_project = project.get_current_project
 
 return M

--- a/lua/project_nvim/init.lua
+++ b/lua/project_nvim/init.lua
@@ -1,8 +1,10 @@
 local config = require("project_nvim.config")
 local history = require("project_nvim.utils.history")
+local project = require("project_nvim.project")
 local M = {}
 
 M.setup = config.setup
 M.get_recent_projects = history.get_recent_projects
+M.get_current_project = project.get_current_project
 
 return M

--- a/lua/project_nvim/init.lua
+++ b/lua/project_nvim/init.lua
@@ -5,6 +5,6 @@ local M = {}
 
 M.setup = config.setup
 M.get_recent_projects = history.get_recent_projects
-M.get_current_project = project.get_current_project
+M.get_current_project = project.get_project_root
 
 return M

--- a/lua/project_nvim/project.lua
+++ b/lua/project_nvim/project.lua
@@ -9,9 +9,6 @@ local M = {}
 M.attached_lsp = false
 M.last_project = nil
 
-function M.get_current_project()
-    return M.last_project
-end
 
 
 function M.find_lsp_root()

--- a/lua/project_nvim/project.lua
+++ b/lua/project_nvim/project.lua
@@ -9,6 +9,11 @@ local M = {}
 M.attached_lsp = false
 M.last_project = nil
 
+function M.get_current_project()
+    return M.last_project
+end
+
+
 function M.find_lsp_root()
   -- Get lsp client for current buffer
   -- Returns nil or string

--- a/lua/project_nvim/project.lua
+++ b/lua/project_nvim/project.lua
@@ -218,7 +218,7 @@ end
 function M.get_current_project()
     local root_dir, _ = M.get_project_root()
     if root_dir then
-        local project_name = path.basename(root_dir)
+        local project_name = root_dir:match("([^/]+)$")
         return project_name
     end
     return nil

--- a/lua/project_nvim/project.lua
+++ b/lua/project_nvim/project.lua
@@ -215,6 +215,15 @@ function M.get_project_root()
   end
 end
 
+function M.get_current_project()
+    local root_dir, _ = M.get_project_root()
+    if root_dir then
+        local project_name = path.basename(root_dir)
+        return project_name
+    end
+    return nil
+end
+
 function M.is_file()
   local buf_type = vim.api.nvim_buf_get_option(0, "buftype")
 


### PR DESCRIPTION
I would like to see the name of the current project on my lueline , so I added `get_current_project()` to the API. Under the hood, it uses `get_project_root` and simply uses regex to take the directory name.

A snazzy screenshot of lualine working nicely with the API:
![image](https://github.com/ahmedkhalf/project.nvim/assets/92609548/b0fa3d41-5cd0-4452-8e42-030e1ffc46a6)