### PR TITLE
feat: Added setup options from telescope

### DIFF
--- a/lua/telescope/_extensions/projects.lua
+++ b/lua/telescope/_extensions/projects.lua
@@ -18,6 +18,14 @@ local history = require("project_nvim.utils.history")
 local project = require("project_nvim.project")
 local config = require("project_nvim.config")
 
+local _opts = {}
+
+-- Setup for telescope
+local function setup(opts_)
+  opts_ = opts_ or {}
+  _opts = vim.tbl_deep_extend("force", _opts, opts_)
+end
+
 ----------
 -- Actions
 ----------
@@ -142,7 +150,7 @@ end
 ---Main entrypoint for Telescope.
 ---@param opts table
 local function projects(opts)
-  opts = opts or {}
+  opts = opts and vim.tbl_deep_extend("force", _opts, opts) or opts
 
   pickers.new(opts, {
     prompt_title = "Recent Projects",
@@ -174,6 +182,7 @@ local function projects(opts)
 end
 
 return telescope.register_extension({
+  setup = setup,
   exports = {
     projects = projects,
   },


### PR DESCRIPTION
## Added setup options from telescope
### Below is an example
plugins/telescope.lua
```lua
 local projects_opts = {
      layout_strategy = "horizontal",
      layout_config = {
        anchor = "N",
        height = 0.25,
        width = 0.6,
        prompt_position = "bottom",
      },
      prompt_prefix = "󱎸  ",
    }

    telescope.setup({
      extensions = {
        projects = projects_opts,
      },
    })
```
![Screenshot from 2024-07-20 02-50-44](https://github.com/user-attachments/assets/903d18a0-be7f-4a68-a3f0-24e8c453488a)

