### PR TITLE
ft: added find_projects api and delete buffers when changing repo

### DIFF
--- a/lua/telescope/_extensions/projects.lua
+++ b/lua/telescope/_extensions/projects.lua
@@ -59,6 +59,14 @@ local function create_finder()
   })
 end
 
+local function delete_buffers()
+  for _, bufnr in ipairs(vim.api.nvim_list_bufs()) do
+    if vim.api.nvim_buf_is_loaded(bufnr) then
+      vim.api.nvim_buf_delete(bufnr, { force = false })
+    end
+  end
+end
+
 local function change_working_directory(prompt_bufnr, prompt)
   local selected_entry = state.get_selected_entry(prompt_bufnr)
   if selected_entry == nil then
@@ -72,6 +80,9 @@ local function change_working_directory(prompt_bufnr, prompt)
     actions.close(prompt_bufnr)
   end
   local cd_successful = project.set_pwd(project_path, "telescope")
+  if cd_successful then
+    delete_buffers()
+  end
   return project_path, cd_successful
 end
 


### PR DESCRIPTION
I added a get_last_project API because when I changed directories, the LazyGit instance in ToggleTerm didn’t update its root path. It kept pointing to the previous repository.

To fix this, I created this API to get the current project path. Now, before launching LazyGit, I can update ToggleTerm's directory to match the current project path.
