### PR TITLE
fix: fixed deprecated function

### DIFF
--- a/lua/project_nvim/project.lua
+++ b/lua/project_nvim/project.lua
@@ -13,7 +13,7 @@ function M.find_lsp_root()
   -- Get lsp client for current buffer
   -- Returns nil or string
   local buf_ft = vim.api.nvim_buf_get_option(0, "filetype")
-  local clients = vim.lsp.buf_get_clients()
+  local clients = vim.lsp.get_clients()
   if next(clients) == nil then
     return nil
   end


### PR DESCRIPTION
`buf_get_clients` is deprecated.  This PR renames it to `get_clients` to fix the deprecation error for recent versions of Neovim.